### PR TITLE
Feat/user level api

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -13,8 +13,8 @@ import answersRouter from "./src/routes/answers.js";
 import communityRouter from "./src/routes/posts.js";
 import reportsRouter from "./src/routes/reports.js";
 import rankingsRouter from "./src/routes/rankings.js";
-import uploadRouter from './src/routes/uploads';
-import commentsRouter from './src/routes/comments.js';
+import uploadRouter from "./src/routes/uploads";
+import commentsRouter from "./src/routes/comments.js";
 import { StatusCodes } from "http-status-codes";
 
 const app = express();

--- a/app.ts
+++ b/app.ts
@@ -14,6 +14,7 @@ import communityRouter from "./src/routes/posts.js";
 import reportsRouter from "./src/routes/reports.js";
 import rankingsRouter from "./src/routes/rankings.js";
 import uploadRouter from './src/routes/uploads';
+import commentsRouter from './src/routes/comments.js';
 import { StatusCodes } from "http-status-codes";
 
 const app = express();
@@ -37,6 +38,7 @@ app.use("/api/posts", communityRouter);
 app.use("/api/reports", reportsRouter);
 app.use("/api/rankings", rankingsRouter);
 app.use("/api/uploads", uploadRouter);
+app.use("/api/comments", commentsRouter);
 
 // 404 처리
 app.use((req, res) => {

--- a/prisma/migrations/20250422014349_user_level/migration.sql
+++ b/prisma/migrations/20250422014349_user_level/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE `User` ADD COLUMN `level` INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN `point` INTEGER NOT NULL DEFAULT 0,
+    MODIFY `profile_image_url` TEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,9 @@ model User {
   password        String               @db.VarChar(60)
   createdAt       DateTime             @default(now()) @map("created_at")
   updatedAt       DateTime             @default(now()) @updatedAt @map("updated_at")
-  profileImageUrl String?              @map("profile_image_url") @db.VarChar(254)
+  profileImageUrl String?              @map("profile_image_url") @db.Text
+  level           Int                  @default(0)
+  point           Int                  @default(0)
   answers         Answer[]
   comments        Comment[]
   favorites       Favorite[]

--- a/src/constants/levelUpPoints.ts
+++ b/src/constants/levelUpPoints.ts
@@ -1,0 +1,4 @@
+export const POST_ANSWER_POINTS = 5;
+export const POST_COMMUNITY_POST_POINTS = 5;
+export const POST_COMMENT_POINTS = 2;
+export const RECEIVE_LIKE_POINTS = 1;

--- a/src/controllers/answerController.ts
+++ b/src/controllers/answerController.ts
@@ -5,6 +5,8 @@ import answerService from "../services/answerService.js";
 import { questionService } from "../services/questionService.js";
 import { AuthRequest } from "../middlewares/authMiddleware.js";
 import { GetAllAnswersRequest } from "./questionsController.js";
+import userService from "../services/userService.js";
+import { POST_ANSWER_POINTS } from "../constants/levelUpPoints.js";
 
 export interface RecordAnswerRequest extends AuthRequest {
   params: {
@@ -38,6 +40,8 @@ export async function recordAnswer(
     }
 
     await answerService.recordAnswer(userId, parseInt(questionId), content);
+
+    await userService.addPointsToUser(userId, POST_ANSWER_POINTS);
 
     res.status(StatusCodes.CREATED).end();
   } catch (error) {

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -147,9 +147,9 @@ export async function login(
       email: user.email,
       nickname: user.nickname,
       positionId: user.positionId ?? 0,
-      level: 0, // TODO: 레벨 추가
+      level: user.level,
       answersCount: userAnswerCount,
-      profileImageUrl: user.profileImageUrl,
+      profileImageUrl: user.profileImageUrl ?? null,
     });
   } catch (error) {
     next(error);

--- a/src/controllers/commentsController.ts
+++ b/src/controllers/commentsController.ts
@@ -121,7 +121,7 @@ export async function checkCommentPermission(
 
 export interface UpdateCommentRequest extends AuthRequest {
   params: {
-    commentId: string;
+    targetId: string;
   };
   body: {
     content: string;
@@ -135,10 +135,10 @@ export async function updateComment(
 ): Promise<void> {
   try {
     const request = req as UpdateCommentRequest;
-    const { commentId } = request.params;
+    const { targetId } = request.params;
     const { content } = request.body;
 
-    await commentService.updateComment(parseInt(commentId), content);
+    await commentService.updateComment(parseInt(targetId), content);
   } catch (error) {
     next(error);
   }
@@ -146,7 +146,7 @@ export async function updateComment(
 
 interface DeleteCommentRequest extends AuthRequest {
   params: {
-    commentId: string;
+    targetId: string;
   };
 }
 
@@ -157,8 +157,8 @@ export async function deleteComment(
 ): Promise<void> {
   try {
     const request = req as DeleteCommentRequest;
-    const { commentId } = request.params;
-    await commentService.deleteComment(parseInt(commentId));
+    const { targetId } = request.params;
+    await commentService.deleteComment(parseInt(targetId));
   } catch (error) {
     next(error);
   }

--- a/src/controllers/commentsController.ts
+++ b/src/controllers/commentsController.ts
@@ -2,6 +2,8 @@ import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import commentService from "../services/commentService";
 import { AuthRequest } from "../middlewares/authMiddleware";
+import userService from "../services/userService";
+import { POST_COMMENT_POINTS } from "../constants/levelUpPoints";
 
 interface GetCommentsRequest extends Request {
   params: {
@@ -77,6 +79,8 @@ export async function addComment(
       content,
       parentId ? parseInt(parentId) : undefined
     );
+
+    await userService.addPointsToUser(request.user.userId, POST_COMMENT_POINTS);
 
     res.status(StatusCodes.CREATED).json(comment);
   } catch (error) {

--- a/src/controllers/favoriteController.ts
+++ b/src/controllers/favoriteController.ts
@@ -84,10 +84,12 @@ export async function addFavorite(
       targetId
     );
 
-    const authorId = await userService.getFavoriteContentAuthor(targetType, targetId);
+    if(targetType !== "QUESTION") {
+      const authorId = await userService.getFavoriteContentAuthor(targetType, targetId);
 
-    if (authorId !== undefined) {
-      await userService.addPointsToUser(authorId, RECEIVE_LIKE_POINTS);
+      if (authorId !== undefined) {
+        await userService.addPointsToUser(authorId, RECEIVE_LIKE_POINTS);
+      }
     }
 
     res.status(StatusCodes.CREATED).json({

--- a/src/controllers/favoriteController.ts
+++ b/src/controllers/favoriteController.ts
@@ -84,8 +84,11 @@ export async function addFavorite(
       targetId
     );
 
-    if(targetType !== "QUESTION") {
-      const authorId = await userService.getFavoriteContentAuthor(targetType, targetId);
+    if (targetType !== "QUESTION") {
+      const authorId = await userService.getFavoriteContentAuthor(
+        targetType,
+        targetId
+      );
 
       if (authorId !== undefined) {
         await userService.addPointsToUser(authorId, RECEIVE_LIKE_POINTS);

--- a/src/controllers/favoriteController.ts
+++ b/src/controllers/favoriteController.ts
@@ -4,6 +4,8 @@ import favoriteService from "../services/favoriteService.js";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { AuthRequest } from "../middlewares/authMiddleware.js";
 import { FavoriteTargetType } from "@prisma/client";
+import userService from "../services/userService.js";
+import { RECEIVE_LIKE_POINTS } from "../constants/levelUpPoints.js";
 
 export async function getFavorites(
   req: Request,
@@ -81,6 +83,12 @@ export async function addFavorite(
       targetType,
       targetId
     );
+
+    const authorId = await userService.getFavoriteContentAuthor(targetType, targetId);
+
+    if (authorId !== undefined) {
+      await userService.addPointsToUser(authorId, RECEIVE_LIKE_POINTS);
+    }
 
     res.status(StatusCodes.CREATED).json({
       message: "추가되었습니다.",

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -94,9 +94,7 @@ export async function getPosts(
       return;
     }
 
-    const posts = await communityService.getPosts(
-      categoryId ? parseInt(categoryId) : undefined
-    );
+    const posts = await communityService.getPosts(parseInt(categoryId));
 
     res.status(StatusCodes.OK).json(posts);
   } catch (error) {

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -3,6 +3,8 @@ import { Request, Response, NextFunction } from "express";
 import { UserInfo } from "../services/authService";
 import communityService from "../services/postService";
 import postMiddleware from "../middlewares/postMiddleware";
+import userService from "../services/userService";
+import { POST_COMMUNITY_POST_POINTS } from "../constants/levelUpPoints";
 
 export interface CreatePostRequest extends Request {
   body: {
@@ -28,6 +30,8 @@ export async function createPost(
     }
 
     const newPost = await communityService.createPost(userId, title, content, categoryId);
+
+    await userService.addPointsToUser(userId, POST_COMMUNITY_POST_POINTS);
 
     res.status(StatusCodes.CREATED).json(newPost);
   } catch (error) {

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -11,7 +11,7 @@ export interface CreatePostRequest extends Request {
     title: string;
     content: string;
     categoryId: number;
-  }
+  };
 }
 
 export async function createPost(
@@ -24,12 +24,19 @@ export async function createPost(
     const { title, content, categoryId } = request.body;
     const userId = (req as Request & { user: UserInfo }).user.userId;
 
-    if(!(await postMiddleware.isValidPostCategory(categoryId))) {
-      res.status(StatusCodes.BAD_REQUEST).json({ message: "존재하지 않는 게시글 카테고리 입니다." });
+    if (!(await postMiddleware.isValidPostCategory(categoryId))) {
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: "존재하지 않는 게시글 카테고리 입니다." });
       return;
     }
 
-    const newPost = await communityService.createPost(userId, title, content, categoryId);
+    const newPost = await communityService.createPost(
+      userId,
+      title,
+      content,
+      categoryId
+    );
 
     await userService.addPointsToUser(userId, POST_COMMUNITY_POST_POINTS);
 
@@ -77,12 +84,19 @@ export async function getPosts(
   try {
     const { categoryId } = req.query as { categoryId: string };
 
-    if (categoryId && !(await postMiddleware.isValidPostCategory(parseInt(categoryId)))) {
-      res.status(StatusCodes.BAD_REQUEST).json({ message: "존재하지 않는 게시글 카테고리 입니다." });
+    if (
+      categoryId &&
+      !(await postMiddleware.isValidPostCategory(parseInt(categoryId)))
+    ) {
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: "존재하지 않는 게시글 카테고리 입니다." });
       return;
     }
 
-    const posts = await communityService.getPosts(categoryId ? parseInt(categoryId) : undefined);
+    const posts = await communityService.getPosts(
+      categoryId ? parseInt(categoryId) : undefined
+    );
 
     res.status(StatusCodes.OK).json(posts);
   } catch (error) {

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -27,10 +27,10 @@ export async function getMe(
     res.status(StatusCodes.OK).json({
       email: user.email,
       nickname: user.nickname,
-      level: 0, // TODO: 레벨 추가
+      level: user.level,
       answersCount: userAnswerCount,
       positionId: user.positionId ?? 0,
-      profileImageUrl: user.profileImageUrl,
+      profileImageUrl: user.profileImageUrl ?? null,
     });
   } catch (error) {
     next(error);

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -17,9 +17,11 @@ import {
 const router = Router();
 
 router
-  .route("/comments")
+  .route("/:targetId")
   .all(authMiddleware.authenticate)
   .post(validateAddComment, addComment)
   .get(validateGetComments, getComments)
   .patch(validateUpdateComment, checkCommentPermission, updateComment)
   .delete(validateDeleteComment, checkCommentPermission, deleteComment);
+
+export default router;

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -15,6 +15,8 @@ export interface UserInfo {
   email: string;
   nickname: string;
   positionId: number;
+  level: number;
+  point: number;
   profileImageUrl?: string;
 }
 
@@ -102,6 +104,16 @@ async function authenticateUser(
 ): Promise<AuthResponse> {
   const user = await prisma.user.findUnique({
     where: { email },
+    select: {
+      id: true,
+      email: true,
+      nickname: true,
+      positionId: true,
+      level: true,
+      point: true,
+      profileImageUrl: true,
+      password: true,
+    },
     include: { refreshTokens: true },
   });
 
@@ -130,7 +142,9 @@ async function authenticateUser(
       email: user.email,
       nickname: user.nickname,
       positionId: user.positionId ?? 0,
-      profileImageUrl: user.profileImageUrl,
+      level: user.level,
+      point: user.point,
+      profileImageUrl: user.profileImageUrl ?? undefined,
     },
     accessToken,
     refreshToken,
@@ -262,6 +276,15 @@ async function changeUserPassword(
 async function getUserByEmail(email: string): Promise<UserInfo> {
   const user = await prisma.user.findUnique({
     where: { email: email },
+    select: {
+      id: true,
+      email: true,
+      nickname: true,
+      positionId: true,
+      level: true,
+      point: true,
+      profileImageUrl: true,
+    },
   });
 
   if (!user) {
@@ -273,7 +296,9 @@ async function getUserByEmail(email: string): Promise<UserInfo> {
     email: user.email,
     nickname: user.nickname,
     positionId: user.positionId ?? 0,
-    profileImageUrl: user.profileImageUrl,
+    level: user.level,
+    point: user.point,
+    profileImageUrl: user.profileImageUrl ?? undefined,
   };
 }
 

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -113,8 +113,8 @@ async function authenticateUser(
       point: true,
       profileImageUrl: true,
       password: true,
+      refreshTokens: true,
     },
-    include: { refreshTokens: true },
   });
 
   if (!user) throw new AuthError("UNAUTHORIZED");

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -134,23 +134,20 @@ async function getUserStats(userId: number): Promise<UserStats> {
 }
 
 function getLevelUpProgress(points: number, level: number){
-  const requiredPoints = calculateTotalRequiredLevelUpPoints(level + 1) - calculateTotalRequiredLevelUpPoints(level);
+  const currentLevelMinPoints = calculateTotalRequiredLevelUpPoints(level);
+  const nextLevelMinPoints = calculateTotalRequiredLevelUpPoints(level + 1);
+  const requiredPoints = nextLevelMinPoints - currentLevelMinPoints;
+  const currentProgress = points - currentLevelMinPoints;
 
   return {
-    currentPoints: points,
+    currentPoints: currentProgress,
     requiredPoints,
-    progressPercent: Math.floor((points / requiredPoints) * 100),
+    progressPercent: Math.floor((currentProgress / requiredPoints) * 100),
   };
 }
 
 function calculateTotalRequiredLevelUpPoints(level: number): number {
-  let total = 0;
-
-  for (let i = 1; i <= level; i++) {
-    total += level * 10;
-  }
-
-  return total;
+  return (level * (level + 1) / 2 * 10);
 }
 
 async function getFavoriteContentAuthor(targetType: FavoriteTargetType, contentId: number) {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -61,6 +61,11 @@ interface UserStats {
   favoriteCount: number; // 받은 좋아요 합계
   communityPostCount: number; // 커뮤니티 게시글 수
   commentCount: number; // 댓글 수
+  levelUpProgress: {
+    currentPoints: number;
+    requiredPoints: number;
+    progressPercent: number;
+  }
 }
 
 async function getUserAnswerCount(userId: number): Promise<number> {
@@ -87,6 +92,8 @@ async function getUserStats(userId: number): Promise<UserStats> {
           comments: true,
         },
       },
+      level: true,
+      point: true,
     },
   });
 
@@ -104,12 +111,14 @@ async function getUserStats(userId: number): Promise<UserStats> {
       getUserCommentFavoriteReceived(userId),
     ])
   ).reduce((acc, curr) => acc + curr, 0);
+  const levelUpProgress = getLevelUpProgress(user.point, user.level);
 
   return {
     answerCount,
     favoriteCount,
     communityPostCount,
     commentCount,
+    levelUpProgress,
   };
 }
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,3 +1,4 @@
+import { FavoriteTargetType } from "@prisma/client";
 import prisma from "../lib/prisma.js";
 
 const userService = {
@@ -8,6 +9,7 @@ const userService = {
   getUserAnswerCount,
   addPointsToUser,
   getLevelUpProgress,
+  getFavoriteContentAuthor,
 };
 
 // 유저가 받은 답변 좋아요 수
@@ -129,6 +131,39 @@ function calculateTotalRequiredLevelUpPoints(level: number): number {
   }
 
   return total;
+}
+
+async function getFavoriteContentAuthor(targetType: FavoriteTargetType, contentId: number) {
+  let userId: number | undefined;
+
+  switch(targetType){
+    case("ANSWER"): {
+      const answer = await prisma.answer.findUnique({
+        where: {id: contentId},
+        select: {userId: true}
+      });
+      userId = answer?.userId;
+      break;
+    }
+    case("COMMENT"): {
+      const comment = await prisma.comment.findUnique({
+        where: {id: contentId},
+        select: {userId: true}
+      });
+      userId = comment?.userId;
+      break;
+    }
+    case("POST"): {
+      const post = await prisma.communityPost.findUnique({
+        where: {id: contentId},
+        select: {userId: true}
+      });
+      userId = post?.userId;
+      break;
+    }
+  }
+
+  return userId;
 }
 
 async function addPointsToUser(userId: number, points: number): Promise<void> {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -76,7 +76,7 @@ interface UserStats {
     currentPoints: number;
     requiredPoints: number;
     progressPercent: number;
-  }
+  };
 }
 
 async function getUserAnswerCount(userId: number): Promise<number> {
@@ -133,7 +133,7 @@ async function getUserStats(userId: number): Promise<UserStats> {
   };
 }
 
-function getLevelUpProgress(points: number, level: number){
+function getLevelUpProgress(points: number, level: number) {
   const currentLevelMinPoints = calculateTotalRequiredLevelUpPoints(level);
   const nextLevelMinPoints = calculateTotalRequiredLevelUpPoints(level + 1);
   const requiredPoints = nextLevelMinPoints - currentLevelMinPoints;
@@ -147,33 +147,36 @@ function getLevelUpProgress(points: number, level: number){
 }
 
 function calculateTotalRequiredLevelUpPoints(level: number): number {
-  return (level * (level + 1) / 2 * 10);
+  return ((level * (level + 1)) / 2) * 10;
 }
 
-async function getFavoriteContentAuthor(targetType: FavoriteTargetType, contentId: number) {
+async function getFavoriteContentAuthor(
+  targetType: FavoriteTargetType,
+  contentId: number
+) {
   let userId: number | undefined;
 
-  switch(targetType){
-    case("ANSWER"): {
+  switch (targetType) {
+    case "ANSWER": {
       const answer = await prisma.answer.findUnique({
-        where: {id: contentId},
-        select: {userId: true}
+        where: { id: contentId },
+        select: { userId: true },
       });
       userId = answer?.userId;
       break;
     }
-    case("COMMENT"): {
+    case "COMMENT": {
       const comment = await prisma.comment.findUnique({
-        where: {id: contentId},
-        select: {userId: true}
+        where: { id: contentId },
+        select: { userId: true },
       });
       userId = comment?.userId;
       break;
     }
-    case("POST"): {
+    case "POST": {
       const post = await prisma.communityPost.findUnique({
-        where: {id: contentId},
-        select: {userId: true}
+        where: { id: contentId },
+        select: { userId: true },
       });
       userId = post?.userId;
       break;
@@ -190,15 +193,17 @@ async function addPointsToUser(userId: number, points: number): Promise<void> {
     },
   });
 
-  if(!user) {
+  if (!user) {
     throw new Error("존재하지 않는 사용자 입니다.");
   }
 
   let currentLevel = user.level as number;
-  const newTotalPoints = user.point + points as number;
-  let totalRequiredPoints = calculateTotalRequiredLevelUpPoints(currentLevel + 1);
+  const newTotalPoints = (user.point + points) as number;
+  let totalRequiredPoints = calculateTotalRequiredLevelUpPoints(
+    currentLevel + 1
+  );
 
-  while(newTotalPoints >= totalRequiredPoints) {
+  while (newTotalPoints >= totalRequiredPoints) {
     currentLevel++;
     totalRequiredPoints = calculateTotalRequiredLevelUpPoints(currentLevel + 1);
   }


### PR DESCRIPTION
사용자 레벨 기능 추가
- 레벨업 기준: 각 레벨 * 10 만큼의 포인트가 쌓였을 때(lv.0 -> lv.1 은 10포인트, lv.1 -> lv.2 는 20포인트, 등등)
- 포인트 획득 기준: 
  - 다른 사람으로부터 답변/게시글/댓글의 즐겨찾기/좋아요 획득(1포인트)
  - 게시글/답변 작성(5포인트)
  - 댓글 작성(2포인트)
- users/stats: 현재 보유 포인트, 레벨업까지 남은 포인트, progress bar 위한 백분율 추가
- auth/login, users/me: 현재 레벨 추가

그 외
- 댓글 router 및 controller 설정에 오류가 있어서 작동하도록 수정했습니다.
- profileImageUrl 타입이 옵셔널 또는 string | null 로 섞여있는 듯 합니다. 추후 통일시키면 좋을 것 같습니다.
- 즐겨찾기 추가를 할 때 존재하지 않는 대상에 대해서도 추가되는 오류를 발견했습니다.
- answerController 파일에서 GetAllAnswersRequest라는 것을 questionsController에서 import하는 코드가 있는데, GetAllAnswersRequest가 현재 리포에서 존재하지 않습니다.