### PR TITLE
Fix/community posts api

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -14,6 +14,7 @@ import communityRouter from "./src/routes/posts.js";
 import reportsRouter from "./src/routes/reports.js";
 import rankingsRouter from "./src/routes/rankings.js";
 import uploadRouter from './src/routes/uploads';
+import commentsRouter from './src/routes/comments.js';
 import { StatusCodes } from "http-status-codes";
 
 const app = express();
@@ -37,6 +38,7 @@ app.use("/api/posts", communityRouter);
 app.use("/api/reports", reportsRouter);
 app.use("/api/rankings", rankingsRouter);
 app.use("/api/uploads", uploadRouter);
+app.use("/api/comments", commentsRouter);
 
 // 404 처리
 app.use((req, res) => {

--- a/prisma/migrations/20250425035630_community_fix/migration.sql
+++ b/prisma/migrations/20250425035630_community_fix/migration.sql
@@ -1,0 +1,23 @@
+-- CreateIndex
+CREATE INDEX `Answer_created_at_idx` ON `Answer`(`created_at`);
+
+-- CreateIndex
+CREATE INDEX `Answer_user_id_created_at_idx` ON `Answer`(`user_id`, `created_at`);
+
+-- CreateIndex
+CREATE INDEX `Answer_user_id_favorite_count_idx` ON `Answer`(`user_id`, `favorite_count`);
+
+-- CreateIndex
+CREATE INDEX `Comment_created_at_idx` ON `Comment`(`created_at`);
+
+-- CreateIndex
+CREATE INDEX `Comment_user_id_created_at_idx` ON `Comment`(`user_id`, `created_at`);
+
+-- CreateIndex
+CREATE INDEX `Comment_user_id_favorite_count_idx` ON `Comment`(`user_id`, `favorite_count`);
+
+-- CreateIndex
+CREATE INDEX `CommunityPost_user_id_created_at_idx` ON `CommunityPost`(`user_id`, `created_at`);
+
+-- CreateIndex
+CREATE INDEX `CommunityPost_user_id_favorite_count_idx` ON `CommunityPost`(`user_id`, `favorite_count`);

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { StatusCodes } from "http-status-codes";
 import { Request, Response, NextFunction } from "express";
 import { UserInfo } from "../services/authService.js";
@@ -92,13 +91,13 @@ export async function getPostDetail(
 
     await communityService.increasePostViewCount(postId);
 
-    const { _count, ...userWithoutCount } = postDetail.user as { _count?: { answers?: number } };
+    const { _count: count, ...userWithoutCount } = postDetail.user as { _count?: { answers?: number } };
 
     res.status(StatusCodes.OK).json({
       ...postDetail,
       user: {
         ...userWithoutCount,
-        answerCount: _count && typeof _count.answers === "number" ? _count.answers : 0,
+        answerCount: count && typeof count.answers === "number" ? count.answers : 0,
       },
     });
   } catch (error) {
@@ -127,13 +126,13 @@ export async function getPosts(
     const posts = await communityService.getPosts(parseInt(categoryId));
 
     res.status(StatusCodes.OK).json(posts.map(post => {
-      const { _count, ...userWithoutCount } = post.user as { _count?: { answers?: number } };
+      const { _count: count, ...userWithoutCount } = post.user as { _count?: { answers?: number } };
 
       return {
         ...post,
         user: {
           ...userWithoutCount,
-          answerCount: _count && typeof _count.answers === "number" ? _count.answers : 0,
+          answerCount: count && typeof count.answers === "number" ? count.answers : 0,
         },
       }
     }));

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -54,7 +54,7 @@ export async function getPostDetail(
     const postDetail = await communityService.getPostDetail(postId);
 
     if (!postDetail) {
-      res.status(StatusCodes.NOT_FOUND).json({ message: "Post not found" });
+      res.status(StatusCodes.NOT_FOUND).json({ message: "존재하지 않는 게시글 입니다." });
       return;
     }
 

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { StatusCodes } from "http-status-codes";
 import { Request, Response, NextFunction } from "express";
 import { UserInfo } from "../services/authService";
@@ -59,7 +60,15 @@ export async function getPostDetail(
 
     await communityService.increasePostViewCount(postId);
 
-    res.status(StatusCodes.OK).json(postDetail);
+    const { _count, ...userWithoutCount } = postDetail.user as { _count?: { answers?: number } };
+
+    res.status(StatusCodes.OK).json({
+      ...postDetail,
+      user: {
+        ...userWithoutCount,
+        answerCount: _count && typeof _count.answers === "number" ? _count.answers : 0,
+      },
+    });
   } catch (error) {
     next(error);
   }
@@ -80,7 +89,17 @@ export async function getPosts(
 
     const posts = await communityService.getPosts(categoryId ? parseInt(categoryId) : undefined);
 
-    res.status(StatusCodes.OK).json(posts);
+    res.status(StatusCodes.OK).json(posts.map(post => {
+      const { _count, ...userWithoutCount } = post.user as { _count?: { answers?: number } };
+
+      return {
+        ...post,
+        user: {
+          ...userWithoutCount,
+          answerCount: _count && typeof _count.answers === "number" ? _count.answers : 0,
+        },
+      }
+    }));
   } catch (error) {
     next(error);
   }

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -47,6 +47,27 @@ export async function createPost(
   }
 }
 
+export async function getPostCategories(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    const categories = await communityService.getPostCategories();
+
+    res.status(StatusCodes.OK).json(categories);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export function passPostOwnershipCheck(
+  req: Request,
+  res: Response,
+) {
+  res.status(StatusCodes.OK).json(true);
+}
+
 interface GetPostDetailRequest extends Request {
   params: {
     postId: string;

--- a/src/middlewares/commentValidator.ts
+++ b/src/middlewares/commentValidator.ts
@@ -39,7 +39,7 @@ const validateParentId = query("parentId")
   .withMessage("부모 댓글 ID는 1 이상의 정수만 가능합니다.");
 
 export const validateGetComments = [
-  validateCommentId,
+  validateTargetId,
   validateCategoryName,
   validationErrorMiddleware,
 ];

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -16,10 +16,31 @@ import {
 
 const router = Router();
 
-router
-  .route("/comments")
-  .all(authMiddleware.authenticate)
-  .post(validateAddComment, addComment)
-  .get(validateGetComments, getComments)
-  .patch(validateUpdateComment, checkCommentPermission, updateComment)
-  .delete(validateDeleteComment, checkCommentPermission, deleteComment);
+router.post(
+  "/:targetId",
+  authMiddleware.authenticate,
+  validateAddComment,
+  addComment
+);
+router.get(
+  "/:targetId",
+  authMiddleware.authenticate,
+  validateGetComments,
+  getComments
+);
+router.patch(
+  "/:commentId",
+  authMiddleware.authenticate,
+  validateUpdateComment,
+  checkCommentPermission,
+  updateComment
+);
+router.delete(
+  "/:commentId",
+  authMiddleware.authenticate,
+  validateDeleteComment,
+  checkCommentPermission,
+  deleteComment
+);
+
+export default router;

--- a/src/routes/comments.ts
+++ b/src/routes/comments.ts
@@ -16,28 +16,26 @@ import {
 
 const router = Router();
 
+router.use(authMiddleware.authenticate);
+
 router.post(
   "/:targetId",
-  authMiddleware.authenticate,
   validateAddComment,
   addComment
 );
 router.get(
   "/:targetId",
-  authMiddleware.authenticate,
   validateGetComments,
   getComments
 );
 router.patch(
   "/:commentId",
-  authMiddleware.authenticate,
   validateUpdateComment,
   checkCommentPermission,
   updateComment
 );
 router.delete(
   "/:commentId",
-  authMiddleware.authenticate,
   validateDeleteComment,
   checkCommentPermission,
   deleteComment

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -3,8 +3,10 @@ import authMiddleware from "../middlewares/authMiddleware.js";
 import {
   createPost,
   deletePost,
+  getPostCategories,
   getPostDetail,
   getPosts,
+  passPostOwnershipCheck,
   updatePost,
 } from "../controllers/postController.js";
 import postMiddleware from "../middlewares/postMiddleware.js";
@@ -43,6 +45,18 @@ router.patch(
   validationErrorMiddleware,
   postMiddleware.checkPostOwnership,
   updatePost
+);
+router.get(
+  "/categories",
+  authMiddleware.authenticate,
+  getPostCategories
+);
+router.get("/:postId/ownership",
+  authMiddleware.authenticate,
+  validatePostId,
+  validationErrorMiddleware,
+  postMiddleware.checkPostOwnership,
+  passPostOwnershipCheck
 );
 router.get(
   "/:postId",

--- a/src/routes/posts.ts
+++ b/src/routes/posts.ts
@@ -19,7 +19,13 @@ import { validationErrorMiddleware } from "../middlewares/validationErrorMiddlew
 
 const router = Router();
 
-router.get("/", authMiddleware.authenticate, getPosts);
+router.get(
+  "/",
+  authMiddleware.authenticate,
+  validatePostQuery,
+  validationErrorMiddleware,
+  getPosts
+);
 router.post(
   "/",
   authMiddleware.authenticate,
@@ -46,12 +52,9 @@ router.patch(
   postMiddleware.checkPostOwnership,
   updatePost
 );
+router.get("/categories", authMiddleware.authenticate, getPostCategories);
 router.get(
-  "/categories",
-  authMiddleware.authenticate,
-  getPostCategories
-);
-router.get("/:postId/ownership",
+  "/:postId/ownership",
   authMiddleware.authenticate,
   validatePostId,
   validationErrorMiddleware,

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -40,6 +40,11 @@ const PostSelect: Prisma.CommunityPostSelect = {
       id: true,
       nickname: true,
       profileImageUrl: true,
+      _count: {
+        select: {
+          answers: true,
+        }
+      }
     },
   },
   createdAt: true,

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -9,6 +9,7 @@ const communityService = {
   deletePost,
   updatePost,
   increasePostViewCount,
+  getPostCategories,
 };
 
 export default communityService;
@@ -28,6 +29,16 @@ async function createPost(
       createdAt: dbDayjs(),
       updatedAt: dbDayjs(),
     },
+  });
+}
+
+async function getPostCategories() {
+  return await prisma.communityPostCategory.findMany({
+    select: {
+      id: true,
+      name: true,
+    },
+    orderBy: { id: "asc" },
   });
 }
 

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -40,6 +40,7 @@ const PostSelect: Prisma.CommunityPostSelect = {
       id: true,
       nickname: true,
       profileImageUrl: true,
+      level: true,
       _count: {
         select: {
           answers: true,

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -39,6 +39,7 @@ const PostSelect: Prisma.CommunityPostSelect = {
     select: {
       id: true,
       nickname: true,
+      profileImageUrl: true,
     },
   },
   createdAt: true,

--- a/src/services/postService.ts
+++ b/src/services/postService.ts
@@ -35,6 +35,7 @@ const PostSelect: Prisma.CommunityPostSelect = {
   id: true,
   title: true,
   content: true,
+  postCategoryId: true,
   user: {
     select: {
       id: true,

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -197,8 +197,10 @@ async function addPointsToUser(userId: number, points: number): Promise<void> {
     throw new Error("존재하지 않는 사용자 입니다.");
   }
 
-  let currentLevel = user.level;
-  const newTotalPoints = (user.point + points);
+  const { level, point } = user as {level: number, point: number};
+
+  let currentLevel = level;
+  const newTotalPoints = point + points;
   let totalRequiredPoints = calculateTotalRequiredLevelUpPoints(
     currentLevel + 1
   );


### PR DESCRIPTION
커뮤니티 게시글 페이지 프론트엔드 작업하며 백엔드 API 수정을 진행했습니다.
- Post
  - 게시글 카테고리 리스트 불러오는 API 추가
  - 게시글의 주인인지 확인하는 API 추가
  - 게시글 상세 정보 조회에 유저 답변 수 항목 추가
- Comment
  - 댓글 API 루트 방식 수정
  - 댓글 조회에 유저 정보 추가