### PR TITLE
feature: 댓글 조회 API에 정렬 옵션 추가

### DIFF
--- a/src/controllers/commentsController.ts
+++ b/src/controllers/commentsController.ts
@@ -12,6 +12,7 @@ interface GetCommentsRequest extends Request {
   };
   query: {
     categoryName: string;
+    orderBy?: string;
     limit: string;
     page: string;
   };
@@ -26,6 +27,8 @@ export async function getComments(
     const request = req as GetCommentsRequest;
     const { targetId } = request.params;
     const { categoryName } = request.query;
+    const orderBy =
+      request.query.orderBy === "createdAt" ? "createdAt" : "favoriteCount";
     const limit =
       request.query.limit === undefined
         ? DEFAULT_PAGINATION_OPTIONS.COMMENT.LIMIT
@@ -38,7 +41,8 @@ export async function getComments(
     const comments = await commentService.getComments(
       parseInt(targetId),
       categoryId,
-      { limit, page }
+      { limit, page },
+      orderBy
     );
 
     if (!comments) {

--- a/src/services/commentService.ts
+++ b/src/services/commentService.ts
@@ -36,14 +36,15 @@ async function checkCommentPermission(
 async function getComments(
   targetId: number,
   categoryId: number,
-  pagination: PaginationOptions
+  pagination: PaginationOptions,
+  orderBy: "createdAt" | "favoriteCount"
 ) {
   const { limit, page } = pagination;
   const { skip, take } = getPagination({ limit, page });
 
   const comments = await prisma.comment.findMany({
     where: { targetId, categoryId },
-    orderBy: { createdAt: "desc" },
+    orderBy: { [orderBy]: "desc" },
     select: {
       id: true,
       content: true,
@@ -58,8 +59,8 @@ async function getComments(
           _count: {
             select: {
               answers: true,
-            }
-          }
+            },
+          },
         },
       },
       parentId: true,


### PR DESCRIPTION
- getComments 함수에 orderBy 파라미터 추가하여 댓글 정렬 방식 설정 가능
- 댓글 조회 시 기본 정렬 기준을 favoriteCount로 변경