### PR TITLE
Fix/trending

### DIFF
--- a/src/controllers/favoriteController.ts
+++ b/src/controllers/favoriteController.ts
@@ -57,7 +57,7 @@ export async function getFavoriteStatus(
       error instanceof PrismaClientKnownRequestError &&
       error.code === "P2025"
     ) {
-      res.status(StatusCodes.NOT_FOUND).json(false);
+      res.status(StatusCodes.OK).json(false);
       return;
     }
     next(error);

--- a/src/services/questionService.ts
+++ b/src/services/questionService.ts
@@ -97,17 +97,9 @@ async function getQuestions(
   const { skip, take } = getPagination({ limit, page });
   const { categoryId, positionId } = options ?? {};
 
-  const weeklyQuestionIds = await prisma.weeklyQuestion
-    .findMany({
-      select: {
-        questionId: true,
-      },
-    })
-    .then((results) => results.map((item) => item.questionId));
-
   const whereClause: Prisma.QuestionWhereInput = {
-    id: {
-      notIn: weeklyQuestionIds,
+    weeklyQuestion: {
+      is: null
     },
     categories: {
       some: {


### PR DESCRIPTION
- trending/posts 반환값에 유저 정보도 포함
- favorite status api 에서 즐겨찾기가 아닌 경우 404 -> 200 + json(false) 반환하도록 수정
- get questions api 에서 두번의 쿼리를 하나로 통합